### PR TITLE
chore: add uint256 typing; upgrade to cairo 0.9.0

### DIFF
--- a/contracts/erc4626/ERC4626.cairo
+++ b/contracts/erc4626/ERC4626.cairo
@@ -139,14 +139,14 @@ end
 @view
 func previewDeposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         assets : Uint256) -> (shares : Uint256):
-    let (shares) = ERC4626_previewDeposit(assets)
+    let (shares : Uint256) = ERC4626_previewDeposit(assets)
     return (shares)
 end
 
 @external
 func deposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         assets : Uint256, receiver : felt) -> (shares : Uint256):
-    let (shares) = ERC4626_deposit(assets, receiver)
+    let (shares : Uint256) = ERC4626_deposit(assets, receiver)
     return (shares)
 end
 
@@ -160,7 +160,7 @@ end
 @view
 func previewMint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         shares : Uint256) -> (assets : Uint256):
-    let (assets) = ERC4626_previewMint(shares)
+    let (assets : Uint256) = ERC4626_previewMint(shares)
     return (assets)
 end
 

--- a/contracts/erc4626/ERC4626.cairo
+++ b/contracts/erc4626/ERC4626.cairo
@@ -4,23 +4,26 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
 from contracts.lib.openzeppelin.token.erc20.library import (
-    ERC20_name, ERC20_symbol, ERC20_totalSupply, ERC20_decimals, ERC20_balanceOf,
-    ERC20_allowance, ERC20_approve, ERC20_transfer, ERC20_transferFrom)
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+    ERC20_approve,
+    ERC20_transfer,
+    ERC20_transferFrom,
+)
 
 from contracts.lib.openzeppelin.utils.constants import TRUE
 
-from contracts.erc4626.library import (
-    ERC4626_initializer, ERC4626_asset, ERC4626_totalAssets,
-    ERC4626_convertToShares, ERC4626_convertToAssets,
-    ERC4626_maxDeposit, ERC4626_previewDeposit, ERC4626_deposit,
-    ERC4626_maxMint, ERC4626_previewMint, ERC4626_mint,
-    ERC4626_maxWithdraw, ERC4626_previewWithdraw, ERC4626_withdraw,
-    ERC4626_maxRedeem, ERC4626_previewRedeem, ERC4626_redeem)
+from contracts.erc4626.library import ERC4626
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        name : felt, symbol : felt, asset_addr : felt):
-    ERC4626_initializer(name, symbol, asset_addr)
+    name : felt, symbol : felt, asset_addr : felt
+):
+    ERC4626.initializer(name, symbol, asset_addr)
     return ()
 end
 
@@ -46,28 +49,32 @@ end
 
 @view
 func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        totalSupply : Uint256):
+    totalSupply : Uint256
+):
     let (totalSupply : Uint256) = ERC20_totalSupply()
     return (totalSupply)
 end
 
 @view
 func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        decimals : felt):
+    decimals : felt
+):
     let (decimals) = ERC20_decimals()
     return (decimals)
 end
 
 @view
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        account : felt) -> (balance : Uint256):
+    account : felt
+) -> (balance : Uint256):
     let (balance : Uint256) = ERC20_balanceOf(account)
     return (balance)
 end
 
 @view
 func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        owner : felt, spender : felt) -> (remaining : Uint256):
+    owner : felt, spender : felt
+) -> (remaining : Uint256):
     let (remaining : Uint256) = ERC20_allowance(owner, spender)
     return (remaining)
 end
@@ -78,21 +85,24 @@ end
 
 @external
 func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        recipient : felt, amount : Uint256) -> (success : felt):
+    recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transfer(recipient, amount)
     return (TRUE)
 end
 
 @external
 func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        sender : felt, recipient : felt, amount : Uint256) -> (success : felt):
+    sender : felt, recipient : felt, amount : Uint256
+) -> (success : felt):
     ERC20_transferFrom(sender, recipient, amount)
     return (TRUE)
 end
 
 @external
 func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        spender : felt, amount : Uint256) -> (success : felt):
+    spender : felt, amount : Uint256
+) -> (success : felt):
     ERC20_approve(spender, amount)
     return (TRUE)
 end
@@ -103,112 +113,128 @@ end
 
 @view
 func asset{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        assetTokenAddress : felt):
-    let (asset : felt) = ERC4626_asset()
+    assetTokenAddress : felt
+):
+    let (asset : felt) = ERC4626.asset()
     return (asset)
 end
 
 @view
 func totalAssets{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        totalManagedAssets : Uint256):
-    let (total : Uint256) = ERC4626_totalAssets()
+    totalManagedAssets : Uint256
+):
+    let (total : Uint256) = ERC4626.totalAssets()
     return (total)
 end
 
 @view
 func convertToShares{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256) -> (shares : Uint256):
-    let (shares : Uint256) = ERC4626_convertToShares(assets)
+    assets : Uint256
+) -> (shares : Uint256):
+    let (shares : Uint256) = ERC4626.convertToShares(assets)
     return (shares)
 end
 
 @view
 func convertToAssets{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256) -> (assets : Uint256):
-    let (assets : Uint256) = ERC4626_convertToAssets(shares)
+    shares : Uint256
+) -> (assets : Uint256):
+    let (assets : Uint256) = ERC4626.convertToAssets(shares)
     return (assets)
 end
 
 @view
 func maxDeposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        receiver : felt) -> (maxAssets : Uint256):
-    let (maxAssets : Uint256) = ERC4626_maxDeposit(receiver)
+    receiver : felt
+) -> (maxAssets : Uint256):
+    let (maxAssets : Uint256) = ERC4626.maxDeposit(receiver)
     return (maxAssets)
 end
 
 @view
 func previewDeposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256) -> (shares : Uint256):
-    let (shares : Uint256) = ERC4626_previewDeposit(assets)
+    assets : Uint256
+) -> (shares : Uint256):
+    let (shares : Uint256) = ERC4626.previewDeposit(assets)
     return (shares)
 end
 
 @external
 func deposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256, receiver : felt) -> (shares : Uint256):
-    let (shares : Uint256) = ERC4626_deposit(assets, receiver)
+    assets : Uint256, receiver : felt
+) -> (shares : Uint256):
+    let (shares : Uint256) = ERC4626.deposit(assets, receiver)
     return (shares)
 end
 
 @view
 func maxMint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        receiver : felt) -> (maxShares : Uint256):
-    let (maxShares : Uint256) = ERC4626_maxMint(receiver)
+    receiver : felt
+) -> (maxShares : Uint256):
+    let (maxShares : Uint256) = ERC4626.maxMint(receiver)
     return (maxShares)
 end
 
 @view
 func previewMint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256) -> (assets : Uint256):
-    let (assets : Uint256) = ERC4626_previewMint(shares)
+    shares : Uint256
+) -> (assets : Uint256):
+    let (assets : Uint256) = ERC4626.previewMint(shares)
     return (assets)
 end
 
 @external
 func mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256, receiver : felt) -> (assets : Uint256):
-    let (assets : Uint256) = ERC4626_mint(shares, receiver)
+    shares : Uint256, receiver : felt
+) -> (assets : Uint256):
+    let (assets : Uint256) = ERC4626.mint(shares, receiver)
     return (assets)
 end
 
 @view
 func maxWithdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        owner : felt) -> (maxAssets : Uint256):
-    let (maxWithdraw : Uint256) = ERC4626_maxWithdraw(owner)
+    owner : felt
+) -> (maxAssets : Uint256):
+    let (maxWithdraw : Uint256) = ERC4626.maxWithdraw(owner)
     return (maxWithdraw)
 end
 
 @view
 func previewWithdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256) -> (shares : Uint256):
-    let (shares : Uint256) = ERC4626_previewWithdraw(assets)
+    assets : Uint256
+) -> (shares : Uint256):
+    let (shares : Uint256) = ERC4626.previewWithdraw(assets)
     return (shares)
 end
 
 @external
 func withdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256, receiver : felt, owner : felt) -> (shares : Uint256):
-    let (shares : Uint256) = ERC4626_withdraw(assets, receiver, owner)
+    assets : Uint256, receiver : felt, owner : felt
+) -> (shares : Uint256):
+    let (shares : Uint256) = ERC4626.withdraw(assets, receiver, owner)
     return (shares)
 end
 
 @view
 func maxRedeem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(owner : felt) -> (
-        maxShares : Uint256):
-    let (maxShares : Uint256) = ERC4626_maxRedeem(owner)
+    maxShares : Uint256
+):
+    let (maxShares : Uint256) = ERC4626.maxRedeem(owner)
     return (maxShares)
 end
 
 @view
 func previewRedeem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256) -> (assets : Uint256):
-    let (assets : Uint256) = ERC4626_previewRedeem(shares)
+    shares : Uint256
+) -> (assets : Uint256):
+    let (assets : Uint256) = ERC4626.previewRedeem(shares)
     return (assets)
 end
 
 @external
 func redeem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256, receiver : felt, owner : felt) -> (assets : Uint256):
-    let (assets : Uint256) = ERC4626_redeem(shares, receiver, owner)
+    shares : Uint256, receiver : felt, owner : felt
+) -> (assets : Uint256):
+    let (assets : Uint256) = ERC4626.redeem(shares, receiver, owner)
     return (assets)
 end

--- a/contracts/erc4626/library.cairo
+++ b/contracts/erc4626/library.cairo
@@ -3,11 +3,24 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address, get_contract_address
 from starkware.cairo.common.uint256 import (
-    ALL_ONES, Uint256, uint256_eq, uint256_add, uint256_mul, uint256_sub, uint256_unsigned_div_rem,
-    uint256_le)
+    ALL_ONES,
+    Uint256,
+    uint256_eq,
+    uint256_add,
+    uint256_mul,
+    uint256_sub,
+    uint256_unsigned_div_rem,
+    uint256_le,
+)
 
 from openzeppelin.token.erc20.library import (
-    ERC20_initializer, ERC20_totalSupply, ERC20_mint, ERC20_burn, ERC20_balanceOf, ERC20_allowances)
+    ERC20_initializer,
+    ERC20_totalSupply,
+    ERC20_mint,
+    ERC20_burn,
+    ERC20_balanceOf,
+    ERC20_allowances,
+)
 from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
 from openzeppelin.utils.constants import FALSE, TRUE
 
@@ -31,279 +44,303 @@ end
 # Initializer
 #
 
-func ERC4626_initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        name : felt, symbol : felt, asset_addr : felt):
-    let (decimals) = IERC20.decimals(contract_address=asset_addr)
-    ERC20_initializer(name, symbol, decimals)
-    ERC4626_asset_addr.write(asset_addr)
-    return ()
-end
+namespace ERC4626:
+    func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        name : felt, symbol : felt, asset_addr : felt
+    ):
+        let (decimals) = IERC20.decimals(contract_address=asset_addr)
+        ERC20_initializer(name, symbol, decimals)
+        ERC4626_asset_addr.write(asset_addr)
+        return ()
+    end
 
-#
-# ERC4626
-#
+    #
+    # ERC4626
+    #
 
-func ERC4626_asset{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        asset : felt):
-    let (asset : felt) = ERC4626_asset_addr.read()
-    return (asset)
-end
+    func asset{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        asset : felt
+    ):
+        let (asset : felt) = ERC4626_asset_addr.read()
+        return (asset)
+    end
 
-func ERC4626_totalAssets{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        totalManagedAssets : Uint256):
-    let (asset : felt) = ERC4626_asset()
-    let (vault : felt) = get_contract_address()
-    let (total : Uint256) = IERC20.balanceOf(contract_address=asset, account=vault)
-    return (total)
-end
+    func totalAssets{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        totalManagedAssets : Uint256
+    ):
+        let (asset : felt) = ERC4626.asset()
+        let (vault : felt) = get_contract_address()
+        let (total : Uint256) = IERC20.balanceOf(contract_address=asset, account=vault)
+        return (total)
+    end
 
-func ERC4626_convertToShares{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256) -> (shares : Uint256):
-    alloc_locals
+    func convertToShares{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        assets : Uint256
+    ) -> (shares : Uint256):
+        alloc_locals
 
-    let (total_supply : Uint256) = ERC20_totalSupply()
-    let (is_total_supply_zero : felt) = uint256_is_zero(total_supply)
+        let (total_supply : Uint256) = ERC20_totalSupply()
+        let (is_total_supply_zero : felt) = uint256_is_zero(total_supply)
 
-    if is_total_supply_zero == TRUE:
-        return (assets)
-    else:
-        let (product : Uint256) = uint256_mul_checked(assets, total_supply)
-        let (total_assets : Uint256) = ERC4626_totalAssets()
-        let (shares, _) = uint256_unsigned_div_rem(product, total_assets)
+        if is_total_supply_zero == TRUE:
+            return (assets)
+        else:
+            let (product : Uint256) = uint256_mul_checked(assets, total_supply)
+            let (total_assets : Uint256) = ERC4626.totalAssets()
+            let (shares, _) = uint256_unsigned_div_rem(product, total_assets)
+            return (shares)
+        end
+    end
+
+    func convertToAssets{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        shares : Uint256
+    ) -> (assets : Uint256):
+        alloc_locals
+
+        let (total_supply : Uint256) = ERC20_totalSupply()
+        let (is_total_supply_zero : felt) = uint256_is_zero(total_supply)
+
+        if is_total_supply_zero == TRUE:
+            return (shares)
+        else:
+            let (total_assets : Uint256) = ERC4626.totalAssets()
+            let (product : Uint256) = uint256_mul_checked(shares, total_assets)
+            let (assets, _) = uint256_unsigned_div_rem(product, total_supply)
+            return (assets)
+        end
+    end
+
+    #
+    # # Deposit
+    #
+
+    func maxDeposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        receiver : felt
+    ) -> (maxAssets : Uint256):
+        let (maxAssets : Uint256) = uint256_max()
+        return (maxAssets)
+    end
+
+    func previewDeposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        assets : Uint256
+    ) -> (shares : Uint256):
+        let (shares) = ERC4626.convertToShares(assets)
         return (shares)
     end
-end
 
-func ERC4626_convertToAssets{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256) -> (assets : Uint256):
-    alloc_locals
+    func deposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        assets : Uint256, receiver : felt
+    ) -> (shares : Uint256):
+        alloc_locals
 
-    let (total_supply : Uint256) = ERC20_totalSupply()
-    let (is_total_supply_zero : felt) = uint256_is_zero(total_supply)
+        let (shares : Uint256) = ERC4626.previewDeposit(assets)
+        let (shares_is_zero : felt) = uint256_is_zero(shares)
+        with_attr error_message("zero shares"):
+            assert shares_is_zero = FALSE
+        end
 
-    if is_total_supply_zero == TRUE:
-        return (shares)
-    else:
-        let (total_assets : Uint256) = ERC4626_totalAssets()
-        let (product : Uint256) = uint256_mul_checked(shares, total_assets)
-        let (assets, _) = uint256_unsigned_div_rem(product, total_supply)
-        return (assets)
-    end
-end
+        let (asset : felt) = ERC4626.asset()
+        let (caller : felt) = get_caller_address()
+        let (vault : felt) = get_contract_address()
 
-#
-# # Deposit
-#
+        let (success : felt) = IERC20.transferFrom(
+            contract_address=asset, sender=caller, recipient=vault, amount=assets
+        )
+        with_attr error_message("transfer failed"):
+            assert success = TRUE
+        end
 
-func ERC4626_maxDeposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        receiver : felt) -> (maxAssets : Uint256):
-    let (maxAssets : Uint256) = uint256_max()
-    return (maxAssets)
-end
+        ERC20_mint(receiver, shares)
 
-func ERC4626_previewDeposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256) -> (shares : Uint256):
-    let (shares) = ERC4626_convertToShares(assets)
-    return (shares)
-end
+        Deposit.emit(caller=caller, owner=receiver, assets=assets, shares=shares)
 
-func ERC4626_deposit{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256, receiver : felt) -> (shares : Uint256):
-    alloc_locals
-
-    let (shares : Uint256) = ERC4626_previewDeposit(assets)
-    let (shares_is_zero : felt) = uint256_is_zero(shares)
-    with_attr error_message("zero shares"):
-        assert shares_is_zero = FALSE
-    end
-
-    let (asset : felt) = ERC4626_asset()
-    let (caller : felt) = get_caller_address()
-    let (vault : felt) = get_contract_address()
-
-    let (success : felt) = IERC20.transferFrom(
-        contract_address=asset, sender=caller, recipient=vault, amount=assets)
-    with_attr error_message("transfer failed"):
-        assert success = TRUE
-    end
-
-    ERC20_mint(receiver, shares)
-
-    Deposit.emit(caller=caller, owner=receiver, assets=assets, shares=shares)
-
-    return (shares)
-end
-
-#
-# # Mint
-#
-
-func ERC4626_maxMint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        receiver : felt) -> (maxShares : Uint256):
-    let (maxShares) = uint256_max()
-    return (maxShares)
-end
-
-func ERC4626_previewMint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256) -> (assets : Uint256):
-    alloc_locals
-
-    let (total_supply : Uint256) = ERC20_totalSupply()
-    let (is_total_supply_zero : felt) = uint256_is_zero(total_supply)
-
-    if is_total_supply_zero == TRUE:
-        return (shares)
-    else:
-        let (total_assets : Uint256) = ERC4626_totalAssets()
-        let (product : Uint256) = uint256_mul_checked(shares, total_assets)
-        let (assets) = uint256_unsigned_div_rem_up(product, total_supply)
-        return (assets)
-    end
-end
-
-func ERC4626_mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256, receiver : felt) -> (assets : Uint256):
-    alloc_locals
-
-    let (assets : Uint256) = ERC4626_previewMint(shares)
-
-    let (asset : felt) = ERC4626_asset()
-    let (caller : felt) = get_caller_address()
-    let (vault : felt) = get_contract_address()
-
-    let (success : felt) = IERC20.transferFrom(
-        contract_address=asset, sender=caller, recipient=vault, amount=assets)
-    with_attr error_message("transfer failed"):
-        assert success = TRUE
-    end
-
-    ERC20_mint(receiver, shares)
-
-    Deposit.emit(caller=caller, owner=receiver, assets=assets, shares=shares)
-
-    return (assets)
-end
-
-#
-# # Withdraw
-#
-
-func ERC4626_maxWithdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        owner : felt) -> (maxAssets : Uint256):
-    let (owner_balance : Uint256) = ERC20_balanceOf(owner)
-    let (maxAssets : Uint256) = ERC4626_convertToAssets(owner_balance)
-    return (maxAssets)
-end
-
-func ERC4626_previewWithdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256) -> (shares : Uint256):
-    alloc_locals
-
-    let (total_supply : Uint256) = ERC20_totalSupply()
-    let (is_total_supply_zero : felt) = uint256_is_zero(total_supply)
-
-    if is_total_supply_zero == TRUE:
-        return (assets)
-    else:
-        let (total_assets : Uint256) = ERC4626_totalAssets()
-        let (product : Uint256) = uint256_mul_checked(assets, total_supply)
-        let (shares : Uint256) = uint256_unsigned_div_rem_up(product, total_assets)
         return (shares)
     end
-end
 
-func ERC4626_withdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        assets : Uint256, receiver : felt, owner : felt) -> (shares : Uint256):
-    alloc_locals
+    #
+    # # Mint
+    #
 
-    let (shares : Uint256) = ERC4626_previewWithdraw(assets)
-
-    let (caller : felt) = get_caller_address()
-
-    if caller != owner:
-        decrease_allowance_by_amount(owner, caller, shares)
-        tempvar syscall_ptr = syscall_ptr
-        tempvar pedersen_ptr = pedersen_ptr
-        tempvar range_check_ptr = range_check_ptr
-    else:
-        tempvar syscall_ptr = syscall_ptr
-        tempvar pedersen_ptr = pedersen_ptr
-        tempvar range_check_ptr = range_check_ptr
+    func maxMint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        receiver : felt
+    ) -> (maxShares : Uint256):
+        let (maxShares) = uint256_max()
+        return (maxShares)
     end
 
-    ERC20_burn(owner, shares)
+    func previewMint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        shares : Uint256
+    ) -> (assets : Uint256):
+        alloc_locals
 
-    let (asset : felt) = ERC4626_asset()
-    let (success : felt) = IERC20.transfer(
-        contract_address=asset, recipient=receiver, amount=assets)
-    with_attr error_message("transfer failed"):
-        assert success = TRUE
+        let (total_supply : Uint256) = ERC20_totalSupply()
+        let (is_total_supply_zero : felt) = uint256_is_zero(total_supply)
+
+        if is_total_supply_zero == TRUE:
+            return (shares)
+        else:
+            let (total_assets : Uint256) = ERC4626.totalAssets()
+            let (product : Uint256) = uint256_mul_checked(shares, total_assets)
+            let (assets) = uint256_unsigned_div_rem_up(product, total_supply)
+            return (assets)
+        end
     end
 
-    Withdraw.emit(caller=caller, receiver=receiver, owner=owner, assets=assets, shares=shares)
+    func mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        shares : Uint256, receiver : felt
+    ) -> (assets : Uint256):
+        alloc_locals
 
-    return (shares)
-end
+        let (assets : Uint256) = ERC4626.previewMint(shares)
 
-#
-# # REDEEM
-#
+        let (asset : felt) = ERC4626.asset()
+        let (caller : felt) = get_caller_address()
+        let (vault : felt) = get_contract_address()
 
-func ERC4626_maxRedeem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        owner : felt) -> (maxShares : Uint256):
-    let (maxShares : Uint256) = ERC20_balanceOf(owner)
-    return (maxShares)
-end
+        let (success : felt) = IERC20.transferFrom(
+            contract_address=asset, sender=caller, recipient=vault, amount=assets
+        )
+        with_attr error_message("transfer failed"):
+            assert success = TRUE
+        end
 
-func ERC4626_previewRedeem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256) -> (assets : Uint256):
-    let (assets : Uint256) = ERC4626_convertToAssets(shares)
-    return (assets)
-end
+        ERC20_mint(receiver, shares)
 
-func ERC4626_redeem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        shares : Uint256, receiver : felt, owner : felt) -> (assets : Uint256):
-    alloc_locals
+        Deposit.emit(caller=caller, owner=receiver, assets=assets, shares=shares)
 
-    let (caller : felt) = get_caller_address()
-
-    if caller != owner:
-        decrease_allowance_by_amount(owner, caller, shares)
-        tempvar syscall_ptr = syscall_ptr
-        tempvar pedersen_ptr = pedersen_ptr
-        tempvar range_check_ptr = range_check_ptr
-    else:
-        tempvar syscall_ptr = syscall_ptr
-        tempvar pedersen_ptr = pedersen_ptr
-        tempvar range_check_ptr = range_check_ptr
+        return (assets)
     end
 
-    let (assets : Uint256) = ERC4626_previewRedeem(shares)
-    let (is_zero_assets : felt) = uint256_is_zero(assets)
-    with_attr error_message("zero assets"):
-        assert is_zero_assets = FALSE
+    #
+    # # Withdraw
+    #
+
+    func maxWithdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt
+    ) -> (maxAssets : Uint256):
+        let (owner_balance : Uint256) = ERC20_balanceOf(owner)
+        let (maxAssets : Uint256) = ERC4626.convertToAssets(owner_balance)
+        return (maxAssets)
     end
 
-    ERC20_burn(owner, shares)
+    func previewWithdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        assets : Uint256
+    ) -> (shares : Uint256):
+        alloc_locals
 
-    let (asset : felt) = ERC4626_asset()
-    let (success : felt) = IERC20.transfer(
-        contract_address=asset, recipient=receiver, amount=assets)
-    with_attr error_message("transfer failed"):
-        assert success = TRUE
+        let (total_supply : Uint256) = ERC20_totalSupply()
+        let (is_total_supply_zero : felt) = uint256_is_zero(total_supply)
+
+        if is_total_supply_zero == TRUE:
+            return (assets)
+        else:
+            let (total_assets : Uint256) = ERC4626.totalAssets()
+            let (product : Uint256) = uint256_mul_checked(assets, total_supply)
+            let (shares : Uint256) = uint256_unsigned_div_rem_up(product, total_assets)
+            return (shares)
+        end
     end
 
-    Withdraw.emit(caller=caller, receiver=receiver, owner=owner, assets=assets, shares=shares)
+    func withdraw{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        assets : Uint256, receiver : felt, owner : felt
+    ) -> (shares : Uint256):
+        alloc_locals
 
-    return (assets)
+        let (shares : Uint256) = ERC4626.previewWithdraw(assets)
+
+        let (caller : felt) = get_caller_address()
+
+        if caller != owner:
+            decrease_allowance_by_amount(owner, caller, shares)
+            tempvar syscall_ptr = syscall_ptr
+            tempvar pedersen_ptr = pedersen_ptr
+            tempvar range_check_ptr = range_check_ptr
+        else:
+            tempvar syscall_ptr = syscall_ptr
+            tempvar pedersen_ptr = pedersen_ptr
+            tempvar range_check_ptr = range_check_ptr
+        end
+
+        ERC20_burn(owner, shares)
+
+        let (asset : felt) = ERC4626.asset()
+        let (success : felt) = IERC20.transfer(
+            contract_address=asset, recipient=receiver, amount=assets
+        )
+        with_attr error_message("transfer failed"):
+            assert success = TRUE
+        end
+
+        Withdraw.emit(caller=caller, receiver=receiver, owner=owner, assets=assets, shares=shares)
+
+        return (shares)
+    end
+
+    #
+    # # REDEEM
+    #
+
+    func maxRedeem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        owner : felt
+    ) -> (maxShares : Uint256):
+        let (maxShares : Uint256) = ERC20_balanceOf(owner)
+        return (maxShares)
+    end
+
+    func previewRedeem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        shares : Uint256
+    ) -> (assets : Uint256):
+        let (assets : Uint256) = ERC4626.convertToAssets(shares)
+        return (assets)
+    end
+
+    func redeem{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        shares : Uint256, receiver : felt, owner : felt
+    ) -> (assets : Uint256):
+        alloc_locals
+
+        let (caller : felt) = get_caller_address()
+
+        if caller != owner:
+            decrease_allowance_by_amount(owner, caller, shares)
+            tempvar syscall_ptr = syscall_ptr
+            tempvar pedersen_ptr = pedersen_ptr
+            tempvar range_check_ptr = range_check_ptr
+        else:
+            tempvar syscall_ptr = syscall_ptr
+            tempvar pedersen_ptr = pedersen_ptr
+            tempvar range_check_ptr = range_check_ptr
+        end
+
+        let (assets : Uint256) = ERC4626.previewRedeem(shares)
+        let (is_zero_assets : felt) = uint256_is_zero(assets)
+        with_attr error_message("zero assets"):
+            assert is_zero_assets = FALSE
+        end
+
+        ERC20_burn(owner, shares)
+
+        let (asset : felt) = ERC4626.asset()
+        let (success : felt) = IERC20.transfer(
+            contract_address=asset, recipient=receiver, amount=assets
+        )
+        with_attr error_message("transfer failed"):
+            assert success = TRUE
+        end
+
+        Withdraw.emit(caller=caller, receiver=receiver, owner=owner, assets=assets, shares=shares)
+
+        return (assets)
+    end
 end
 
 #
 # allowance helper
 #
 
-func decrease_allowance_by_amount{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        owner : felt, spender : felt, amount : Uint256):
+func decrease_allowance_by_amount{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}(owner : felt, spender : felt, amount : Uint256):
     alloc_locals
 
     let (spender_allowance : Uint256) = ERC20_allowances.read(owner, spender)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-cairo-lang==0.7.1
+cairo-lang==0.9.0
 ecdsa==0.17.0
 fastecdsa==2.2.1
 pytest==6.2.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from typing import Callable, Tuple
 from utils import Signer, str_to_felt, to_uint
 
 import pytest
-from starkware.starknet.services.api.contract_definition import ContractDefinition
+from starkware.starknet.services.api.contract_class import ContractClass
 from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starknet.testing.starknet import Starknet, StarknetContract
 
@@ -18,7 +18,7 @@ def contract_path(contract_name: str) -> str:
     return os.path.join(here(), "..", "contracts", "erc4626", contract_name)
 
 
-def compile_contract(contract_name: str) -> ContractDefinition:
+def compile_contract(contract_name: str) -> ContractClass:
     contract_src = contract_path(contract_name)
     return compile_starknet_files(
         [contract_src],
@@ -30,7 +30,7 @@ def compile_contract(contract_name: str) -> ContractDefinition:
     )
 
 
-def compile_mock_contract(contract_name: str) -> ContractDefinition:
+def compile_mock_contract(contract_name: str) -> ContractClass:
     contract_src = os.path.join(here(), "mocks", contract_name)
     return compile_starknet_files(
         [contract_src], debug_info=True, cairo_path=[os.path.join(here(), "mocks")]
@@ -60,7 +60,7 @@ def users(starknet) -> Callable[[str], Tuple[Signer, StarknetContract]]:
 
         signer = Signer(abs(hash(name)))
         account = await starknet.deploy(
-            contract_def=account_contract, constructor_calldata=[signer.public_key]
+            contract_class=account_contract, constructor_calldata=[signer.public_key]
         )
 
         user = (signer, account)
@@ -76,7 +76,7 @@ async def asset(starknet, users) -> StarknetContract:
     _, asset_owner = await users("asset_owner")
 
     return await starknet.deploy(
-        contract_def=contract,
+        contract_class=contract,
         constructor_calldata=[
             str_to_felt("Winning"),  # name
             str_to_felt("WIN"),  # symbol
@@ -93,7 +93,7 @@ async def erc4626(starknet, asset) -> StarknetContract:
     contract = compile_contract("ERC4626.cairo")
 
     return await starknet.deploy(
-        contract_def=contract,
+        contract_class=contract,
         constructor_calldata=[
             str_to_felt("Vault of Winning"),
             str_to_felt("vWIN"),
@@ -105,4 +105,4 @@ async def erc4626(starknet, asset) -> StarknetContract:
 @pytest.fixture(scope="session")
 async def terc4626(starknet) -> StarknetContract:
     contract = compile_contract("test_ERC4626.cairo")
-    return await starknet.deploy(contract_def=contract)
+    return await starknet.deploy(contract_class=contract)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from starkware.starknet.business_logic.transaction_execution_objects import Event
+from starkware.starknet.business_logic.execution.objects import Event
 from starkware.cairo.common.hash_state import compute_hash_on_elements
 from starkware.crypto.signature.signature import private_to_stark_key, sign
 from starkware.starknet.public.abi import get_selector_from_name


### PR DESCRIPTION
**What I did**
- Add `Uint256` typing for consistency.
- Upgrade to Cairo `0.9.0`.
- Add ERC4626 namespace.